### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/giovannimazzuoccolo/dutchfordevelopers/security/code-scanning/1](https://github.com/giovannimazzuoccolo/dutchfordevelopers/security/code-scanning/1)

In general, the fix is to explicitly restrict the `GITHUB_TOKEN` permissions used by this workflow to the minimal set required. Since this CI workflow only checks out code and runs Node.js tests, it only needs read access to repository contents. The best fix is to add a `permissions` block at the workflow root (top level, alongside `name` and `on`), which will apply to all jobs in this file unless overridden.

Concretely, in `.github/workflows/ci.yml`, add:

```yaml
permissions:
  contents: read
```

between the `name: CI` line and the `on:` block. This does not change any functional behavior of the CI job other than limiting the implicit capabilities of `GITHUB_TOKEN`. No additional imports, methods, or definitions are needed; it is purely a configuration change within the YAML workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
